### PR TITLE
Added markdown block template support and full YAML processing

### DIFF
--- a/examples/apps/simple/docs/extend.md
+++ b/examples/apps/simple/docs/extend.md
@@ -1,0 +1,16 @@
+---
+template: mytemplate
+---
+
+
+@@block:part1@@
+
+This is the content of part 1.
+
+@@endblock@@
+
+@@block:part2@@
+
+This is the content of part 2.
+
+@@endblock@@

--- a/examples/apps/simple/docs/mytemplate.mdt
+++ b/examples/apps/simple/docs/mytemplate.mdt
@@ -1,0 +1,7 @@
+# This is a template page
+
+## Part 1
+@@block('part1')@@
+
+## Part 2
+@@block('part2')@@

--- a/examples/apps/simple/settings.json
+++ b/examples/apps/simple/settings.json
@@ -8,6 +8,7 @@
         "items": [
           { "title": "Home", "url": "/" },
           { "title": "Format", "url": "/format" },
+          { "title": "Templated Page", "url": "/extend" },
           { "title": "Subtree Doc", "url": "/subtree/document"}
         ]
       }

--- a/lib/markdocs/app.js
+++ b/lib/markdocs/app.js
@@ -36,6 +36,8 @@ function App(options, app){
     app = arguments[2];
   }
 
+  options = options || {};
+
   events.EventEmitter.call(this);
 
   var self = this;

--- a/lib/markdocs/doc.js
+++ b/lib/markdocs/doc.js
@@ -5,6 +5,7 @@
 var fs = require('fs');
 var path = require('path');
 var showdown = require('showdown');
+var matter = require('gray-matter');
 
 /**
  * Parse metadata from `Document` content
@@ -17,10 +18,6 @@ var showdown = require('showdown');
  * #Title
  * More content
 */
-
-var DOC_RE = /^(?:[\s\n\r]*---\s*(?:[\n\r]+((?:.|[\r\n])*))?[\n\r]+---\s*(?:[\n\r]+|$))?((?:.|[\r\n])*)?$/;
-var META_RE = /^\s*([\w]+)\s*:\s*(.*)\s*$/mg;
-var META_ITEM_RE = /^\s*([\w]+)\s*:\s*(.*)\s*$/;
 
 /**
  * Expose `Doc`
@@ -38,23 +35,19 @@ module.exports = Doc;
 
 function Doc(app, filename){
   var self = this;
-  var data = DOC_RE.exec(fs.readFileSync(path.resolve(app.getDocsPath(), filename), 'utf8'));
+
+  var data = matter(fs.readFileSync(path.resolve(app.getDocsPath(), filename), 'utf8'));
 
   this._app = app;
   this._filename = path.normalize(filename);
 
-  this._meta = {};
-  if (data[1] && (ms = data[1].match(META_RE))) {
-      ms.forEach(function(m){
-        m = META_ITEM_RE.exec(m);
-        self._meta[m[1]] = m[2];
-      });
-  }
+  this._meta = data.data || {};
+  var content = data.content || '';
+
   if (!this._meta.url) {
     this._meta.url = '/' + this._filename.replace(/\.[\w]+$/, '');
   }
 
-  var content = data[2] || '';
   if (this._meta.template) {
     var template = fs.readFileSync(path.resolve(app.getDocsPath(), this._meta.template + '.mdt'), 'utf8');
     content = this._processTemplate(template, content);
@@ -84,7 +77,7 @@ Doc.prototype.getUrl = function() {
  */
 
 Doc.prototype.isPublic = function() {
-  return this._meta.public !== 'false';
+  return this._meta.public !== false;
 };
 
 /**

--- a/lib/markdocs/doc.js
+++ b/lib/markdocs/doc.js
@@ -154,5 +154,9 @@ Doc.prototype._processTemplate = function(template, content) {
        template = template.replace('@@block(\'' + name + '\')@@', data);
       }
     }
+
+    // Clean up any remaining blocks (all blocks are optional)
+    template = template.replace(/@@block\('.*'\)@@/, '');
+
     return template;
 };

--- a/lib/markdocs/doc.js
+++ b/lib/markdocs/doc.js
@@ -54,8 +54,14 @@ function Doc(app, filename){
     this._meta.url = '/' + this._filename.replace(/\.[\w]+$/, '');
   }
 
+  var content = data[2] || '';
+  if (this._meta.template) {
+    var template = fs.readFileSync(path.resolve(app.getDocsPath(), this._meta.template + '.mdt'), 'utf8');
+    content = this._processTemplate(template, content);
+  }
+
   //TODO: implement section files
-  this._sections = { 'content': data[2] || '' };
+  this._sections = { 'content': content };
 
 }
 
@@ -135,4 +141,18 @@ Doc.prototype.processSections = function(context) {
     sections[sname] = converter.makeHtml(this._sections[sname]);
   }
   return sections;
+};
+
+Doc.prototype._processTemplate = function(template, content) {
+    var parts = content.split('@@endblock@@');
+    var re = /@@block:(.*)@@([^]*)/;
+    for (var i = 0; i < parts.length; i++) {
+      var matches = re.exec(parts[i]);
+      if (matches) {
+       var name = matches[1];
+       var data = matches[2].trim();
+       template = template.replace('@@block(\'' + name + '\')@@', data);
+      }
+    }
+    return template;
 };

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "commander": "1.0.5",
     "express": "~3.18.6",
+    "gray-matter": "^2.0.0",
     "jade": "0.27.7",
     "less": "1.3.1",
     "lsr": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "markdocs",
   "description": "Simple docs for apps with markdown",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "Auth0",
   "dependencies": {
     "commander": "1.0.5",


### PR DESCRIPTION
Added the ability to use one markdown document `mytemplate.mdt` as a template for other documents.

Usage is:

Template file:

```md
# Template

## Part 1
@@block('part1')@@

```

child file:
```md
---
template:  mytemplate
---

@@block:part1@@

### foo
block content

@@endblock@@
```